### PR TITLE
Add reference tracking to the infrastructure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,6 +114,17 @@ jobs:
         file: interpellation-questions_${{ env.INTERPELLATIONS_TAG }}.zip
         tag: ${{ github.ref }}
 
+    - name: Generate Reference List
+      run: |
+        PYTHONPATH="$PYTHONPATH:." python references/compile-reference-list.py --output-file swerik-reference-list_${{ github.ref_name }}.bib
+
+    - name: Upload Reference List to Release
+      uses: svenstaro/upload-release-action@v2
+      with:
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: swerik-reference-list_${{ github.ref_name }}.bib
+        tag: ${{ github.ref }}
+
     - name: Generate README
       run: |
         PYTHONPATH="$PYTHONPATH:." python readme/src/generate-markdown.py -v ${{ github.ref_name }} -pv ${{ env.PERSONS_TAG }} -rv ${{ env.RECORDS_TAG }} -py ${{ env.PYRIKSDAGEN_TAG }} -mv ${{ env.MOTIONS_TAG }} -iv ${{ env.INTERPELLATIONS_TAG }} -sv ${{ env.SCRIPTS_TAG }} -r ${{ env.RCR_TAG }}

--- a/references/README.md
+++ b/references/README.md
@@ -1,0 +1,65 @@
+# References
+
+This directory contains bibliographic information of works cited within the SWERIK corpora. The sub-directory `bibtex/` contains `.bib` files for each reference. A single `.bib` file can be compiled using `compile-reference-list.py`.
+
+
+## Conventions
+
+Each file contained in the `bibfiles/` directory is named the same as its citation key + `.bib`. Citation keys have the following conventions:
+
+### Single-author works
+
+Single author works are named `authorsurnameYEAR` in all lowercase, e.g.
+
+	smith1984
+
+unless the surname has a prefix, then the surname is cammel case starting with a lower case letter, e.g.
+
+	vanHout1999
+
+
+### Two-author works
+
+Works with two authors are cited like `Author1Author2YEAR`, e.g.:
+
+	SmithAndersson2002
+
+Surname prefixes are lowercase for author 1 and uppercase for author two.
+
+	SmithVanHout1982
+
+
+### More than two authors
+
+Multi-author (3+) works are cited as `Author1EAYEAR`, e.g.:
+
+	AnderssonEA2019
+
+First-author prefixes remain lower-case
+
+vanHoutEA2022
+
+
+### Undated works
+
+Undated works follow the same conventions as above, but instead `YEAR` is replaced with `ND`+`single descriptive word` in lower case or multiword starting with lowercase and Camel case for all words after word1
+
+	AnderssonNDsvenskKokbok 
+
+
+### Busy authors
+
+Authors that have multiple works in the same year receive descriptive-word suffixes as in Undated works to distinguish works penned in the same year.
+
+	magnusson2020critiqueOfTraditionalStatistics
+	magnusson2020bayesianIsBetter
+
+
+### Works with volumes
+
+Works with multiple volumes are suffixed with `v1`, `v2`, etc
+
+	NorbergEA1988v1
+	NorbergEA1988v2
+
+Do this even if the years and / or authorship is different.

--- a/references/bibtex/AskerNorberg1996v1.bib
+++ b/references/bibtex/AskerNorberg1996v1.bib
@@ -1,0 +1,10 @@
+@book{AskerNorberg1996v1,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Sveriges riksdag},
+title = {Enkammarriksdagen 1971-1993/94 : ledamöter och valkretsar. Bd 1 Stockholms kommun, Stockholms län, Uppsala län, Södermanlands län, Östergötlands län, Jönköpings län, Kronobergs län, Kalmar län, Gotlands län, Blekinge län, Kristianstads län, Fyrstadskretsen, Malmöhus län, register band 1-2},
+year = {1996},
+author = {Björn Asker and Anders Norberg},
+address = {Stockholm},
+isbn = {9188398145}
+}

--- a/references/bibtex/NorbergAsker1996v2.bib
+++ b/references/bibtex/NorbergAsker1996v2.bib
@@ -1,0 +1,11 @@
+@book{NorbergAsker1996v2,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Sveriges riksdag},
+title = {Enkammarriksdagen 1971-1993/94 : ledamöter och valkretsar. Bd 2 Hallands län, Göteborgs kommun, Bohuslän, Älvsborgs läns norra, Älvsborgs läns södra, Skaraborgs län, Värmlands län, Örebro län, Västmanlands län, Kopparbergs län, Gävleborgs län, Västernorrlands län, Jämtlands län, Västerbottens län, Norrbottens län, register band 1-2},
+year = {1996},
+author = {Anders Norberg and Björn Asker},
+address = {Stockholm},
+isbn = {9188398161}
+}
+

--- a/references/bibtex/NorbergEA1986v3.bib
+++ b/references/bibtex/NorbergEA1986v3.bib
@@ -1,0 +1,11 @@
+@book{NorbergEA1986v3,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Almqvist & Wiksell International},
+title = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 3 Blekinge län, Kristianstads län, Malmöhus län},
+year = {1986},
+author = {Anders Norberg and Andreas Tjerneld and Björn Asker},
+address = {Stockholm},
+isbn = {9122008543}
+}
+

--- a/references/bibtex/NorbergEA1988v1.bib
+++ b/references/bibtex/NorbergEA1988v1.bib
@@ -1,0 +1,11 @@
+@book{NorbergEA1988v1,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Almqvist & Wiksell International},
+title = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 1 Stockholms stad, Stockholms län, Uppsala län, Södermanlands län, Västmanlands län},
+year = {1988},
+author = {Anders Norberg and Andreas Tjerneld and Björn Asker},
+address = {Stockholm},
+isbn = {9122012869}
+}
+

--- a/references/bibtex/NorbergEA1990v4.bib
+++ b/references/bibtex/NorbergEA1990v4.bib
@@ -1,0 +1,11 @@
+@book{NorbergEA1990v4,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Almqvist & Wiksell International},
+title = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 4 Göteborgs och Bohus län, Älvsborgs län, Skaraborgs län, Värmlands län, Örebro län},
+year = {1990},
+author = {Anders Norberg and Andreas Tjerneld and Björn Asker},
+address = {Stockholm},
+isbn = {9122013415}
+}
+

--- a/references/bibtex/NorbergEA1992v5.bib
+++ b/references/bibtex/NorbergEA1992v5.bib
@@ -1,0 +1,11 @@
+@book{NorbergEA1992v5,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Almqvist & Wiksell International},
+title = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 5 Kopparbergs län, Gävleborgs län, Västernorrlands län, Jämtlands län, Västerbottens län, Norrbottens län, register band 1-5},
+year = {1992},
+author = {Anders Norberg and Andreas Tjerneld and Björn Asker},
+address = {Stockholm},
+isbn = {9122014969}
+}
+

--- a/references/bibtex/NorbergTjerneld1985v2.bib
+++ b/references/bibtex/NorbergTjerneld1985v2.bib
@@ -1,0 +1,12 @@
+@book{NorbergTjerneld1985v2,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Almqvist & Wiksell International},
+title = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 2 Östergötlands län, Jönköpings län, Kronobergs län, Kalmar län, Gotlands län, Hallands län },
+year = {1985},
+author = {Anders Norberg and Andreas Tjerneld},
+address = {Stockholm},
+booktitle = {Tvåkammarriksdagen 1867-1970 : ledamöter och valkretsar. Bd 2 Östergötlands län, Jönköpings län, Kronobergs län, Kalmar län, Gotlands län, Hallands län},
+isbn = {9122007741}
+}
+

--- a/references/bibtex/statisticsSweden2025partyDistr.bib
+++ b/references/bibtex/statisticsSweden2025partyDistr.bib
@@ -1,0 +1,9 @@
+@misc{statisticsSweden2025partyDistr,
+    title = {Riksdagsledamöter, antal efter region, parti, kön, tabellinnehåll och valår},
+    author = {{Statistics Sweden}},
+    organization = {Statistics Sweden},
+    address = {Stockholm, Sweden},
+    year = {2025},
+    url = {https://api.scb.se/OV0104/v1/doris/sv/ssd/ME/ME0107/ME0107C/Riksdagsledamoter},
+    note = {[Data accessed 2025-01-24 19:01:52.755821 using pxweb R package 0.17.0]}
+}

--- a/references/bibtex/stjernquist1992.bib
+++ b/references/bibtex/stjernquist1992.bib
@@ -1,0 +1,9 @@
+@incollection{stjernquist1992,
+author = {Nils Stjernquist},
+title = {Riksdagen i vår tid: perioden från 1921},
+booktitle = {Riksdagen genom tiderna},
+pages = {255--359},
+editor = {Herman Schück and Göran Rystad and Michael F Metcalf and Scen Carlsson and Nils Sthernquist},
+publisher = {Sveriges Riksdag/Stiftelsen Riksbankens Jibileumsfond},
+year = {1992}
+}

--- a/references/bibtex/stjernquist1996.bib
+++ b/references/bibtex/stjernquist1996.bib
@@ -1,0 +1,12 @@
+@book{stjernquist1996,
+keywords = {Sverige Riksdagen},
+language = {swe},
+publisher = {Sveriges riksdag},
+title = {Tvåkammartiden : Sveriges riksdag 1867-1970 },
+year = {1996},
+author = {Stjernquist, Nils},
+address = {Stockholm},
+booktitle = {Tvåkammartiden : Sveriges riksdag 1867-1970},
+isbn = {9188398196}
+}
+

--- a/references/compile-reference-list.py
+++ b/references/compile-reference-list.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""
+Compile `references/bibtex/*.bib` to a single reference list file.
+"""
+from glob import glob
+from tqdm import tqdm
+import argparse
+import warnings
+
+
+
+
+
+def validate_bib_data(data, bib):
+    OK = True
+    errors = []
+    if not data[0].startswith("@"):
+        errors.append("First line of .bib needs to start with '@'.")
+        OK = False
+
+    try:
+        bibtype, key = data[0].split("{")
+        #print(filename, key[:-1], filename[:-4])
+        if key[:-1] != bib.split("/")[-1][:-4]:
+            errors.append("Key must be the same as the filename without '.bib'.")
+            if not key.endswith(","):
+                errors.append("Malformed first line. (missing comma?)")
+            OK = False
+    except:
+        errors.append("Malformed first line.")
+        OK = False
+
+    for ix, l in enumerate(data, start=1):
+        #print(ix, l)
+        if ix != 1 and ix != len(data) and ix != len(data)-1:
+            if not l.endswith(","):
+                errors.append(f"Line {ix} (1 index) doesn't end with a comma and it should.")
+                OK = False
+        if ix == len(data):
+            if not l == "}":
+                errors.append("Last line must == '}'")
+                OK = False
+        if ix != 1 and ix != len(data):
+            if "=" not in l:
+                errors.append(f"Line {ix} (1 index) is malformed. Must contain '='.")
+                OK = False
+        if ix == len(data)-1:
+            if l.endswith(","):
+                errors.append("Second to last line shouln't end with a comma, but it does.")
+                OK = False
+    # More validation (planned?):
+    # --- reference type (right of @) are from valid set
+    # --- Fields (left of =) are from valid set
+
+    if OK:
+        return True, errors
+    else:
+        return False, errors
+
+
+
+
+def main(args):
+
+    with open(args.output_file, "w+") as outf:
+        for bib in tqdm(sorted(glob(f"{args.bibfiles}*.bib"))):
+            print(bib)
+            with open(bib, 'r') as inf:
+                data = [l.strip() for l in inf.readlines() if l.strip() != ""]
+
+            valid, errors = validate_bib_data(data, bib)
+            if valid:
+                for idx, l in enumerate(data):
+                    if idx == 0 or idx == len(data)-1:
+                        outf.write(f"{l}\n")
+                    else:
+                        outf.write(f"    {l}\n")
+                outf.write("\n\n")
+            else:
+                warnings.warn(f"There are some problems with bibfile: {bib}")
+                [print(f"  ~~ {e}\n") for e in errors]
+
+
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("-b", "--bibfiles",
+                        type=str,
+                        default="./references/bibtex/",
+                        help="Directory where bibtex files are stored.")
+    parser.add_argument("-o", "--output-file",
+                        type=str,
+                        default="./references/_compiled-references.bib",
+                        help="Where do you want the compiled reference list?")
+    args = parser.parse_args()
+    main(args)


### PR DESCRIPTION
With this, we get a place to store references in bibtex format. On release, each bibtex file is validated and dumped to a unified file that gets appended to the release.