### PR TITLE
Decision dcat

### DIFF
--- a/docs/decisions/decision-0023_data-repo-source-metadata.md
+++ b/docs/decisions/decision-0023_data-repo-source-metadata.md
@@ -1,0 +1,126 @@
+# Data repo source metadata
+
+## Context
+
+SWERIK data repositories need machine-readable metadata for several purposes:
+catalogue harvesting, citation, publication, search indexing, research data
+repositories, generated documentation, and release checks. The immediate need is
+to publish DCAT-AP-SE metadata for dataportal.se and data.europa.eu, but the
+same repository facts are also relevant for SND/DORIS, Dataverse, Schema.org
+JSON-LD, README summaries, release pages, and other discovery or publication
+workflows.
+
+At the same time, the word "metadata" is already used in the corpus context for
+metadata that belongs to the research data itself. Examples include person
+metadata, party affiliations, document dates, identifiers, signatories,
+chambers, sessions, XML attributes, CSV tables, and CSVW descriptions of public
+tables. Users may analyze this metadata as part of their research.
+
+We therefore need a clear distinction between:
+
+- research data metadata, which is part of the corpus data model and is used by
+  researchers;
+- data repo source metadata, which describes a repository or released dataset as
+  a publishable source for discovery, citation, catalogue harvesting, and
+  archival workflows to alight with FAIR principles.
+
+Keeping these concepts separate avoids confusing user-facing corpus metadata
+with project/release metadata used by infrastructure.
+
+## Decision
+
+SWERIK distinguishes research data metadata from data repo source metadata.
+
+Research data metadata is metadata that forms part of the data users analyze or
+use to interpret the corpus. It may live in `metadata/`, `data/`, CSV files, XML
+files, schemas, CSVW files, or other corpus-specific locations depending on the
+repository. This decision does not change how research metadata is stored.
+
+Data repo source metadata is metadata that describes a data repository or
+released dataset as a source to be discovered, cited, harvested, published, and
+archived. It includes facts such as title, description, publisher, contact
+point, license, version, release date, landing page, repository URL, download
+URLs, file formats, temporal coverage, languages, keywords, citation
+information, quality documentation, test documentation, and related resources.
+
+Each SWERIK data repository should store its canonical data repo source metadata
+under:
+
+```text
+config/source-metadata/[repo-name].yml
+```
+
+For example:
+
+```text
+config/source-metadata/riksdagen-records.yml
+config/source-metadata/riksdagen-persons.yml
+config/source-metadata/riksdagen-motions.yml
+```
+
+The file name should match the repository name. This makes the file unambiguous
+when metadata is copied, aggregated, validated, or used by the umbrella
+repository.
+
+The source metadata file should be the human-maintained source of truth for
+repository-level publication metadata. Catalogue-specific and publication-
+specific files should be generated from, or validated against, this source where
+practical. Possible generated or validated outputs include:
+
+- DCAT-AP-SE RDF/XML for dataportal.se harvesting;
+- DCAT Turtle for human review and debugging;
+- Schema.org JSON-LD for search engines;
+- Dataverse metadata;
+- SND/DORIS metadata;
+- README and release-page metadata summaries;
+- repository catalogues in the Swedish Parliament Corpus umbrella repository;
+- other future catalogue, archive, or discovery formats.
+
+Generated publication artifacts may be written to `docs/` when they are intended
+to be served by GitHub Pages or another documentation site. For DCAT, the
+recommended generated layout is:
+
+```text
+docs/dcat/[repo-name].rdf
+docs/dcat/[repo-name].ttl
+```
+
+The RDF/XML file is the harvestable machine-facing artifact. The Turtle file is
+for human review and debugging. Both should be treated as generated publication
+artifacts unless a repository explicitly documents another maintenance model.
+
+The `metadata/` directory should not be used for data repo source metadata when
+that would conflict with research data metadata. Repositories may continue to use
+`metadata/` for corpus-internal or research-facing metadata.
+
+Source metadata files should use stable, absolute URLs and identifiers when they
+describe public resources. For catalogue outputs, generated metadata should
+avoid blank nodes for core resources such as catalogues, datasets,
+distributions, publishers, and contacts.
+
+## Consequences
+
+The same repository facts can be reused across several publication workflows
+instead of being copied into separate hand-maintained DCAT, Dataverse, SND,
+README, and web-page files.
+
+Users and maintainers get a clearer boundary between metadata that is part of
+the research data and metadata that describes the repository as a source.
+Researchers can continue to look for corpus-internal metadata in the data model,
+while infrastructure code can look for publication metadata in
+`config/source-metadata/`.
+
+DCAT work for dataportal.se can start from
+`config/source-metadata/riksdagen-records.yml` and generate
+`docs/dcat/riksdagen-records.rdf` and `docs/dcat/riksdagen-records.ttl`. The
+same pattern can later be reused for `riksdagen-persons`, `riksdagen-motions`,
+and other SWERIK data repositories.
+
+Release automation becomes responsible for keeping generated metadata current.
+Tests should check that source metadata is valid, generated outputs are not
+stale, required catalogue fields are present, public URLs are absolute, and
+generated RDF avoids unsupported blank nodes.
+
+Adding this source metadata layer introduces one more maintained file per data
+repository, but it reduces drift across catalogues, citation files, release
+pages, and documentation.

--- a/docs/decisions/decision-0023_data-repo-source-metadata.md
+++ b/docs/decisions/decision-0023_data-repo-source-metadata.md
@@ -22,7 +22,7 @@ We therefore need a clear distinction between:
   researchers;
 - data repo source metadata, which describes a repository or released dataset as
   a publishable source for discovery, citation, catalogue harvesting, and
-  archival workflows to alight with FAIR principles.
+  archival workflows to align with FAIR principles.
 
 Keeping these concepts separate avoids confusing user-facing corpus metadata
 with project/release metadata used by infrastructure.
@@ -61,6 +61,65 @@ config/source-metadata/riksdagen-motions.yml
 The file name should match the repository name. This makes the file unambiguous
 when metadata is copied, aggregated, validated, or used by the umbrella
 repository.
+
+The source metadata file should use a common set of top-level slots. For
+`riksdagen-records`, the initial file should contain at least:
+
+```yaml
+metadata_type: data_repo_source_metadata
+metadata_version: 1
+
+repository:
+  name: riksdagen-records
+  url: https://github.com/swerik-project/riksdagen-records
+  issue_tracker_url: https://github.com/swerik-project/riksdagen-records/issues
+
+dataset:
+  identifier: riksdagen-records
+  title:
+    en: "The Swedish Parliament Corpus: Riksdagen Records"
+    sv: "Sveriges riksdagskorpus: riksdagsprotokoll"
+  description:
+    en: ""
+    sv: ""
+  temporal_coverage:
+    start: ""
+    end: ""
+  languages:
+    - sv
+  keywords:
+    en: []
+    sv: []
+  type: dataset
+
+publisher:
+  name:
+    en: Uppsala University
+    sv: Uppsala universitet
+  identifier: ""
+  url: https://www.uu.se/
+
+contact:
+  name: ""
+  email: ""
+  url: ""
+
+documentation:
+  readme_url: https://github.com/swerik-project/riksdagen-records#readme
+
+citation:
+  cff_url: https://github.com/swerik-project/riksdagen-records/blob/main/CITATION.cff
+
+relations:
+  related_repositories:
+    - https://github.com/swerik-project/riksdagen-persons
+```
+
+The exact values may be completed incrementally, but the top-level slots should
+remain stable so tooling can validate and transform the file across
+repositories. Empty strings and empty lists are acceptable while the first
+metadata files are being drafted, but release automation should eventually fail
+for required public-catalogue fields that are still empty.
 
 The source metadata file should be the human-maintained source of truth for
 repository-level publication metadata. Catalogue-specific and publication-

--- a/docs/decisions/decision-0023_data-repo-source-metadata.md
+++ b/docs/decisions/decision-0023_data-repo-source-metadata.md
@@ -2,7 +2,8 @@
 
 ## Context
 
-SWERIK data repositories need machine-readable metadata for several purposes:
+SWERIK data repositories need machine-readable metadata for the repositories 
+for several purposes:
 catalogue harvesting, citation, publication, search indexing, research data
 repositories, generated documentation, and release checks. The immediate need is
 to publish DCAT-AP-SE metadata for dataportal.se and data.europa.eu, but the
@@ -10,63 +11,49 @@ same repository facts are also relevant for SND/DORIS, Dataverse, Schema.org
 JSON-LD, README summaries, release pages, and other discovery or publication
 workflows.
 
-At the same time, the word "metadata" is already used in the corpus context for
-metadata that belongs to the research data itself. Examples include person
-metadata, party affiliations, document dates, identifiers, signatories,
-chambers, sessions, XML attributes, CSV tables, and CSVW descriptions of public
-tables. Users may analyze this metadata as part of their research.
-
 We therefore need a clear distinction between:
 
-- research data metadata, which is part of the corpus data model and is used by
+- research data, which is part of the corpus data model and is used by
   researchers;
-- data repo source metadata, which describes a repository or released dataset as
+- repository information, which describes a repository or released dataset as
   a publishable source for discovery, citation, catalogue harvesting, and
   archival workflows to align with FAIR principles.
 
-Keeping these concepts separate avoids confusing user-facing corpus metadata
-with project/release metadata used by infrastructure.
+Keeping these concepts separate avoids confusing user-facing corpus data
+with project/release information used by infrastructure.
 
 ## Decision
 
-SWERIK distinguishes research data metadata from data repo source metadata.
-
-Research data metadata is metadata that forms part of the data users analyze or
-use to interpret the corpus. It may live in `metadata/`, `data/`, CSV files, XML
-files, schemas, CSVW files, or other corpus-specific locations depending on the
-repository. This decision does not change how research metadata is stored.
-
-Data repo source metadata is metadata that describes a data repository or
+Repository information is metadata that describes a repository or
 released dataset as a source to be discovered, cited, harvested, published, and
 archived. It includes facts such as title, description, publisher, contact
 point, license, version, release date, landing page, repository URL, download
 URLs, file formats, temporal coverage, languages, keywords, citation
 information, quality documentation, test documentation, and related resources.
 
-Each SWERIK data repository should store its canonical data repo source metadata
-under:
+Each SWERIK data repository should store its canonical repository information under:
 
 ```text
-config/source-metadata/[repo-name].yml
+docs/[repo-name]-info.yml
 ```
 
 For example:
 
 ```text
-config/source-metadata/riksdagen-records.yml
-config/source-metadata/riksdagen-persons.yml
-config/source-metadata/riksdagen-motions.yml
+docs/riksdagen-records-info.yml
+docs/riksdagen-persons-info.yml
+docs/riksdagen-motions-info.yml
 ```
 
 The file name should match the repository name. This makes the file unambiguous
-when metadata is copied, aggregated, validated, or used by the umbrella
+when metadata on the repo is copied, aggregated, validated, or used by the umbrella
 repository.
 
-The source metadata file should use a common set of top-level slots. For
+The repository info file should use a common set of top-level slots. For
 `riksdagen-records`, the initial file should contain at least:
 
 ```yaml
-metadata_type: data_repo_source_metadata
+metadata_type: repository_information
 metadata_version: 1
 
 repository:
@@ -78,13 +65,10 @@ dataset:
   identifier: riksdagen-records
   title:
     en: "The Swedish Parliament Corpus: Riksdagen Records"
-    sv: "Sveriges riksdagskorpus: riksdagsprotokoll"
+    sv: "Sveriges riksdagskorpus: Riksdagsprotokoll"
   description:
     en: ""
     sv: ""
-  temporal_coverage:
-    start: ""
-    end: ""
   languages:
     - sv
   keywords:
@@ -115,13 +99,13 @@ relations:
     - https://github.com/swerik-project/riksdagen-persons
 ```
 
-The exact values may be completed incrementally, but the top-level slots should
+The exact values will be completed incrementally as needs is identified, but the top-level slots should
 remain stable so tooling can validate and transform the file across
 repositories. Empty strings and empty lists are acceptable while the first
 metadata files are being drafted, but release automation should eventually fail
 for required public-catalogue fields that are still empty.
 
-The source metadata file should be the human-maintained source of truth for
+The info file should be the human-maintained source of truth for
 repository-level publication metadata. Catalogue-specific and publication-
 specific files should be generated from, or validated against, this source where
 practical. Possible generated or validated outputs include:
@@ -148,11 +132,7 @@ The RDF/XML file is the harvestable machine-facing artifact. The Turtle file is
 for human review and debugging. Both should be treated as generated publication
 artifacts unless a repository explicitly documents another maintenance model.
 
-The `metadata/` directory should not be used for data repo source metadata when
-that would conflict with research data metadata. Repositories may continue to use
-`metadata/` for corpus-internal or research-facing metadata.
-
-Source metadata files should use stable, absolute URLs and identifiers when they
+Repository info files should use stable, absolute URLs and identifiers when they
 describe public resources. For catalogue outputs, generated metadata should
 avoid blank nodes for core resources such as catalogues, datasets,
 distributions, publishers, and contacts.
@@ -163,23 +143,23 @@ The same repository facts can be reused across several publication workflows
 instead of being copied into separate hand-maintained DCAT, Dataverse, SND,
 README, and web-page files.
 
-Users and maintainers get a clearer boundary between metadata that is part of
-the research data and metadata that describes the repository as a source.
+Users and maintainers get a clearer boundary between repo info that is part of
+the data and metadata that describes the repository as a source.
 Researchers can continue to look for corpus-internal metadata in the data model,
 while infrastructure code can look for publication metadata in
-`config/source-metadata/`.
+`docs`.
 
 DCAT work for dataportal.se can start from
-`config/source-metadata/riksdagen-records.yml` and generate
+`docs/riksdagen-records.yml` and generate
 `docs/dcat/riksdagen-records.rdf` and `docs/dcat/riksdagen-records.ttl`. The
 same pattern can later be reused for `riksdagen-persons`, `riksdagen-motions`,
 and other SWERIK data repositories.
 
-Release automation becomes responsible for keeping generated metadata current.
+Release automation becomes responsible for keeping generated repo information current.
 Tests should check that source metadata is valid, generated outputs are not
 stale, required catalogue fields are present, public URLs are absolute, and
 generated RDF avoids unsupported blank nodes.
 
-Adding this source metadata layer introduces one more maintained file per data
+Adding this repository information layer introduces one more maintained file per data
 repository, but it reduces drift across catalogues, citation files, release
 pages, and documentation.

--- a/docs/decisions/decision-0023_data-repo-source-metadata.md
+++ b/docs/decisions/decision-0023_data-repo-source-metadata.md
@@ -37,12 +37,10 @@ Each SWERIK data repository should store its canonical repository information un
 docs/[repo-name]-info.yml
 ```
 
-For example:
+For example (in the `riksdagen-records` repo):
 
 ```text
 docs/riksdagen-records-info.yml
-docs/riksdagen-persons-info.yml
-docs/riksdagen-motions-info.yml
 ```
 
 The file name should match the repository name. This makes the file unambiguous


### PR DESCRIPTION
## Summary

Adds a decision for how SWERIK data repositories should store source metadata used for discovery, citation, catalogue harvesting, and publication workflows.

## Main Points

- Distinguishes research data metadata from data repo source metadata.
- Defines `config/source-metadata/[repo-name].yml` as the canonical source metadata location.
- Recommends generated publication outputs such as `docs/dcat/[repo-name].rdf` and `.ttl`.
- Adds an initial example slot structure for `riksdagen-records`.
- Keeps the decision broad enough for DCAT, Dataverse, SND/DORIS, Schema.org, README summaries, and future catalogue formats.

## Notes

This prepares the ground for implementing DCAT metadata for dataportal.se and data.europa.eu after the decision is accepted.